### PR TITLE
TSERV-261 Groovy DSL documentation

### DIFF
--- a/modules/groovy-dsl/Assertions.md
+++ b/modules/groovy-dsl/Assertions.md
@@ -1,0 +1,99 @@
+# Assertions
+
+Until you've added assertions to your DSL script, you're not really testing your application. You're just checking that 
+it doesn't blow up in your face when you access it.
+
+## Generally useful assertions
+
+### responseContains
+
+Checks whether the body of the HTTP response contains a string or something matching a regular expression.
+
+**Arguments:** A string to look for, and optionally parameters that indicate whether the string should be 
+used as a regular expression (```useRegexp```)and whether the search should ignore case (```ignoreCase```).
+
+
+**Examples:** 
+```groovy
+ get 'https://staging-server/customers/1', {
+     asserting {
+         /* matches Smith, SMITH etc */
+         responseContains 'smith', ignoreCase: true
+     }
+ }
+ get 'https://staging-server/customers/1', {
+      asserting {
+          /* matches Smith, SMITH etc, but also any of those strings with an s appended to it */
+          responseContains 'smith(s)?', ignoreCase: true, useRegexp: true
+      }
+  }
+ ```
+The first assertion will accept Smith, SMITH etc. The second one will use "smith(s)" as a regular expression, so it will
+also accept Smiths and SMITHS, for instance.
+
+### responseDoesNotContain
+
+This is simply the inverse of ```responseContains``` (see above). It will assert that the response content does **not**
+contain a string or match a regular expression.
+
+**Arguments:** A string to look for, and optionally key-value pairs that indicate whether the string should be 
+used as a regular expression (```useRegexp```)and whether the search should ignore case (```ignoreCase```).
+
+
+**Examples:** 
+```groovy
+ get 'https://staging-server/customers/1', {
+     asserting {
+         /* matches content not containing the text "smith" */
+         responseDoesNotContain 'smith', ignoreCase: false
+     }
+ }
+ get 'https://staging-server/customers/1', {
+      asserting {
+          /* will fail for all content that contains either "smith" or "smiths" */
+          responseContains 'smith(s)?', ignoreCase: false, useRegexp: true
+      }
+  }
+ ```
+The first assertion will accept Smith, SMITH etc. The second one will use "smith(s)" as a regular expression and will thus
+also accept e.g. Smiths and SMITHS.
+
+## HTTP-specific assertions
+
+These assertions can be added to both REST and SOAP requests but obviously don't make any sense for database responses.
+
+### status
+
+Checks the HTTP status of the response.
+
+**Argument:** One status, or a a comma-separated list of statuses.
+
+**Example:** 
+```groovy
+ get 'https://staging-server/customers/1', {
+     asserting {
+         status 200
+     }
+ }
+ get 'https://staging-server/orders/1/status', {
+     asserting {
+         status 200, 201
+     }
+ }
+     
+ ```
+
+### statusNotIn
+
+Checks that the HTTP status of the response is not in a list of unacceptable statuses.
+
+**Argument:** A comma-separated list of unacceptable statuses.
+
+**Examples:** 
+```groovy
+ get 'https://staging-server/customers/1', {
+     asserting {
+         statusNotIn 400, 401, 500
+     }
+ }
+ ```

--- a/modules/groovy-dsl/Assertions.md
+++ b/modules/groovy-dsl/Assertions.md
@@ -3,10 +3,15 @@
 Until you've added assertions to your DSL script, you're not really testing your application. You're just checking that 
 it doesn't blow up in your face when you access it.
 
+If you do add assertions, steps in your test will be marked as FAILED if the assertions fail. If not, they will have status
+ERROR if the request itself fails (e.g. because of network connectivity issues), but if a response is received the 
+status will be set to UNKNOWN. If no steps have the status FAILED or ERROR, the test will automatically be considered
+successful.
+
 Assertions are always added in an ```asserting``` section right after the request step. See the assertion descriptions below 
 for examples.
 
-##<a name="http-specific"></a> Standard assertions
+##<a name="standard"></a> Standard assertions
 
 This group of assertions can be applied to anything that returns a response: REST and SOAP requests as well as JDBC (database) 
 requests.
@@ -171,7 +176,7 @@ use XPath or XQuery to make advanced assertions on the content.
 
 ##<a name="http-specific"></a> HTTP-specific assertions
 
-These assertions can be added to both REST and SOAP requests but obviously don't make any sense for other test steps.
+These assertions can be added to both REST and SOAP requests but don't make any sense for test steps that are not HTTP-based.
 
 ### status
 

--- a/modules/groovy-dsl/Assertions.md
+++ b/modules/groovy-dsl/Assertions.md
@@ -9,7 +9,22 @@ status will be set to UNKNOWN. If no steps have the status FAILED or ERROR, the 
 successful.
 
 Assertions are always added in an ```asserting``` section right after the request step. See the assertion descriptions below 
-for examples.
+for examples. In addition to the assertions listed below, there are specialized assertions [for REST requests](Rest-Request.md#adding-assertions-to-the-response) 
+and [for JDBC requests](Jdbc-Request.md#adding-assertions-to-the-jdbc-response)
+
+### Available assertions
+
+[Standard assertions](#standard-assertions)
++ [responseContains](#responsecontains)
++ [responseDoesNotContain](#responsedoesnotcontain)
++ [maxResponseTime](#maxresponsetime)
++ [script](#script)
++ [xpath/xQuery <EXPRESSION> contains <EXPECTED_CONTENT>](#xpathxquery--contains-expected_content)
+
+[HTTP-specific assertions](#http-specific-assertions)
++ [status](#status)
++ [statusNotIn](#statusnotin)
++ [responseContentType](#responsecontenttype)
 
 ## Standard assertions
 
@@ -99,8 +114,8 @@ Note that the last two expressions are equivalent.
  
 ### script
  
-Uses a Groovy script to perform an assertion using the current test state. This is an advanced assertion that 
-assumes that the user is familiar with the SoapUI object model. For information about how Groovy script assertions
+Uses a Groovy script to perform an assertion using the state of the currently executing test. This is an advanced assertion that 
+assumes that the user is familiar with the [SoapUI object model](https://www.soapui.org/scripting---properties/the-soapui-object-model.html). For information about how Groovy script assertions
 work, see [this page](https://www.soapui.org/functional-testing/validating-messages/using-script-assertions.html).
 
 Usually this script will be in the form ```assert <BOOLEAN_EXPRESSION>``` - if the boolean expression is false,
@@ -117,46 +132,16 @@ the assertion will fail.
   }
   ```
   
-## XPath/XQuery assertions
-
-
-
-XPath and XQuery assertions have identical syntax - the only difference between them is the former start with
-```xpath``` and the latter with ```xQuery```.
-
 ### xpath/xQuery <EXPRESSION> contains <EXPECTED_CONTENT>
 
-Extracts the element in the response matching the XPath in ```EXPRESSION``` and fails the assertion 
-if it isn't equal to ```EXPECTED_CONTENT```.
+XPath and XQuery assertions have identical syntax - the only difference between them is the former start with
+```xpath``` and the latter with ```xQuery```. 
 
-When validating response content, the XPath and XQuery are much more useful than you'd think.
+When validating response content, XPath and XQuery are much more useful than you'd think.
 HTML responses, JSON responses and JDBC (databases) responses can all be coerced to XML, which means you can
 use XPath or XQuery to make advanced assertions on the content.
-
-**Parameters:** A string containing the XPath/XQuery expression and another string with the expected content.
-
-**Examples:** 
-```groovy
- get 'https://staging-server/customers/1', {
-     asserting {
-         xpath '/customer/id' contains 'JonSnow'
-     }
- }
- get 'https://staging-server/products/1', {
-      asserting {
-          xQuery '/customers[id == "JonSnow"]/id' contains 'JonSnow'
-      }
-  }
- ```
- 
-### xQuery <EXPRESSION> contains <EXPECTED_CONTENT>
-
 Extracts the element in the response matching the XPath in ```EXPRESSION``` and fails the assertion 
 if it isn't equal to ```EXPECTED_CONTENT```.
-
-When validating response content, the XPath and XQuery are much more useful than you'd think.
-HTML responses, JSON responses and JDBC (databases) responses can all be coerced to XML, which means you can
-use XPath or XQuery to make advanced assertions on the content.
 
 **Parameters:** A string containing the XPath/XQuery expression and another string with the expected content.
 

--- a/modules/groovy-dsl/Assertions.md
+++ b/modules/groovy-dsl/Assertions.md
@@ -11,7 +11,7 @@ successful.
 Assertions are always added in an ```asserting``` section right after the request step. See the assertion descriptions below 
 for examples.
 
-##<a name="standard"></a> Standard assertions
+## Standard assertions
 
 This group of assertions can be applied to anything that returns a response: REST and SOAP requests as well as JDBC (database) 
 requests.
@@ -174,7 +174,7 @@ use XPath or XQuery to make advanced assertions on the content.
   }
  ```
 
-##<a name="http-specific"></a> HTTP-specific assertions
+## HTTP-specific assertions
 
 These assertions can be added to both REST and SOAP requests but don't make any sense for test steps that are not HTTP-based.
 

--- a/modules/groovy-dsl/Datasources.md
+++ b/modules/groovy-dsl/Datasources.md
@@ -1,0 +1,102 @@
+# Datasources
+
+Datasources is likely the most complex feature in the Assert4J Test DSL, and unless you've already used DataSources in 
+[ReadyApi](https://smartbear.com/product/ready-api/overview/) or SoapUI Pro you may need some time to understand how to use them. 
+
+Arguably, it's also the most powerful feature in the DSL, however.
+
+***NOTE:*** Datasources are only available for TestServer executions, not for local executions. In other words you need a ReadyApi TestServer 
+to be able to use them.
+
+## How Datasources work
+ 
+The idea of a Datasource is that it will loop over a number of data records. In every iteration, it will set one variable 
+per column in the datasource, and will pass these variables to a number of test steps.
+
+To insert the variables in your test you will then use SoapUI [property expansion](https://www.soapui.org/scripting---properties/property-expansion.html).
+
+For instance, assume that you have an Excel file called ```cities.xls``` with the following contents:
+
+|Country|City|
+|-------|-----|
+|France | Paris |
+|Sweden | Stockholm |
+|Italy | Rome |
+
+
+
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+  executeRecipe {
+    soapRequest {
+           wsdl = 'http://www.webservicex.com/globalweather.asmx?WSDL'
+           binding = 'GlobalWeatherSoap12'
+           operation = 'GetCitiesByCountry'
+           namedParam 'CountryName', 'France'
+           asserting {
+               responseContains 'Paris'
+               responseDoesNotContain 'London'
+               maxResponseTime 3500 ms
+           }
+       }
+     
+  }
+```
+
+## Adding assertions to the SOAP response
+
+To verify that you are getting the expected response back from your web service, you should add assertions to the SOAP
+ request step. This is done in an ```asserting``` section in your configuration block.
+
+In addition to the general-purpose [assertions](Assertions.md#standard-assertions) for things like simple content and the response
+time, there are more specific assertions for checking the correctness of the web service response. The XPath assertions 
+are particularly useful for SOAP responses since they will always be in XML format.
+
+The [HTTP-specific assertions](Assertions.md#http-specific-assertions) are also applicable to all SOAP requests – 
+
+The following complete code example shows you three generic content and response time assertions:
+
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+  executeRecipe {
+    soapRequest {
+           wsdl = 'http://www.webservicex.com/globalweather.asmx?WSDL'
+           binding = 'GlobalWeatherSoap12'
+           operation = 'GetCitiesByCountry'
+           namedParam 'CountryName', 'France'
+           asserting {
+               responseContains 'Paris'
+               responseDoesNotContain 'London'
+               maxResponseTime 3500 ms
+           }
+       }
+     
+  }
+```
+
+The following code example demonstrates the use of the HTTP status assertion, and the two SOAP-specific assertions ```notSoapFault``` and
+```schemaCompliance```. The former will fail if a SOAP fault is returned by the web service; the latter if the response
+payload doesn't comply with the schema defined in the WSDL of the web service.
+
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+  executeRecipe {
+    soapRequest {
+           wsdl = 'http://www.webservicex.com/globalweather.asmx?WSDL'
+           binding = 'GlobalWeatherSoap12'
+           operation = 'GetCitiesByCountry'
+           namedParam 'CountryName', 'France'
+           asserting {
+               status 200
+               notSoapFault
+               schemaCompliance
+           }
+       }
+     
+  }
+```
+
+

--- a/modules/groovy-dsl/Datasources.md
+++ b/modules/groovy-dsl/Datasources.md
@@ -1,19 +1,17 @@
 # Datasources
 
-Datasources is likely the most complex feature in the Assert4J Test DSL, and unless you've already used DataSources in 
-[ReadyApi](https://smartbear.com/product/ready-api/overview/) or SoapUI Pro you may need some time to understand how to use them. 
-
-Arguably, it's also the most powerful feature in the DSL, however, so it's very likely that it will be worth the investment. 
+Arguably, Datasources are the most powerful feature in the DSL. 
 Datasources allow you to easily make your test data-driven and thus much more relevant and to generate test data if you don't have
 it. Read on to learn the basic concepts and syntax of DataSources.
 
 ***NOTE:*** Datasources are only available for TestServer executions, not for local executions. In other words you need a ReadyApi TestServer 
-to be able to use them.
+to be able to use them. The most straightforward way to do this is to use the method ```executeRecipeOnServer``` -
+see the code samples below.
 
 ## How Datasources work
  
-The idea of a Datasource is that it will loop over a number of data records. In every iteration, it will set one variable 
-per column in the datasource, and will pass these variables to a number of test steps.
+The idea of a Datasource is that it will loop over a number of data records. In every iteration, it will set one property 
+per column in the datasource, and will pass these property to a number of test steps.
 
 To insert the variables in your test you will then use SoapUI [property expansion](https://www.soapui.org/scripting---properties/property-expansion.html).
 
@@ -31,7 +29,7 @@ We're now going to use this data to execute the same test (two test steps) once 
 ```groovy
  import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
  
-  executeRecipe {
+  executeRecipeOnServer 'https://testserver_host:8080/', 'user', 'pwd', {
     /* Loop over all the rows in the Excel file. */
     usingExcelFile 'cities.xls', {
     
@@ -91,7 +89,7 @@ the data that we saw in the Excel example above:
  import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
  
   def data = [Country: ['France', 'Sweden', 'Italy'], City: ['Paris', 'Stockholm', 'Rome']]
-  executeRecipe {
+  executeRecipeOnServer 'https://testserver_host:8080/', 'user', 'pwd', {
     /* Loop over all the rows in the data. */
     usingData data, {
     
@@ -136,7 +134,7 @@ The following code will then execute the same tests as the Excel example above:
 ```groovy
  import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
  
-  executeRecipe {
+  executeRecipeOnServer 'https://testserver_host:8080/', 'user', 'pwd', {
     /* Loop over all the rows in the Excel file. */
     usingCsvFile 'cities.xls', {
     

--- a/modules/groovy-dsl/Jdbc-Request.md
+++ b/modules/groovy-dsl/Jdbc-Request.md
@@ -1,0 +1,154 @@
+# Database requests in Assert4J DSL
+
+The Assert4J DSL can access relational databases, and also some NoSQL databases. using JDBC - the standard Java API
+for database access. To add a database request to a test recipe, you call the method ```jdbcRequest``` and specify
+parameters in a configuration block enclosed by curly braces – { and }.
+
+ 
+Here's an example where you connect to a MySQL database on the server staging-server and execute the query 
+```select * from customers```:
+ 
+ ```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+  executeRecipe {
+     jdbcRequest {
+            driver 'com.mysql.Driver'
+            connectionString 'jdbc:mysql://staging-server/staging'
+            query 'select * from customers'
+     }
+     
+  }
+  ```
+
+For this to work, you need to specify which JDBC driver to use and also make sure that the driver in question is on 
+the classpath where the recipe is executed. For more information about JDBC, see Oracle's 
+[JDBC tutorial](https://docs.oracle.com/javase/tutorial/jdbc/index.html).
+
+Because of the way in which JDBC handles stored procedures, you need to set an additional parameter if you are 
+executing a procedure:
+
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+  executeRecipe {
+     jdbcRequest {
+            driver 'com.mysql.Driver'
+            connectionString 'jdbc:mysql://staging-server/staging'
+            query "register_customer('JonSnow')"
+            storedProcedure true
+     }
+     
+  }
+  ```
+Note that because the query itself contains single quotes, in this case we quote the query using double quotes. In the Test DSL,
+and in Groovy generally, it often doesn't matter if you use single or double quotes. If you want to learn more about 
+Groovy string literals, see [this page](http://docs.groovy-lang.org/latest/html/documentation/index.html#all-strings).
+
+**Technical note**: A configuration block is a Groovy closure, which will be executed before the request is sent. 
+In other words, you can insert Groovy code inside it. You can also add comments to document what you're doing.
+ 
+## Adding assertions to the JDBC response
+
+To veryify that the database request didn't just complete but also returned what you expected, you need to add assertions
+to your JDBC request step. To detect that an error was returned from the database, you need to add the 
+[jdbcStatusOk assertion](#jdbcStatusOk) The standard assertions [general-purpose assertions](Assertions.md#standard). 
+
+The following complete code example shows you how to verify that you got a result containing the text "JonSnow" back within
+3 seconds:
+
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+  executeRecipe {
+     jdbcRequest {
+         driver 'com.mysql.Driver'
+         connectionString 'jdbc:mysql://staging-server/staging'
+         query 'select * from customers'
+         asserting {
+            jdbcStatusOk
+            responseContains 'JonSnow'
+            maxResponseTime 3 seconds
+         }
+     }
+  }
+  ```
+The XPath assertions are surprisingly useful for verifying the results you get back. This is because the results are
+wrapped in XML. For instance, if you're selecting one row with the columns CustomerId and Age from a table, you will get XML like the 
+following back:
+
+```xml
+<Results fetchSize="0">
+   <ResultSet>
+        <Row>
+            <CustomerId>JonSnow</CustomerId>
+            <Age>25</Age>
+        </Row>
+    </ResultSet>
+</Results>
+```
+The following code will assert that the returned CustomerId value is "JonSnow":
+
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+  executeRecipe {
+     jdbcRequest {
+         driver 'com.mysql.Driver'
+         connectionString 'jdbc:mysql://staging-server/staging'
+         query "select CustomerId, Age from Customers where SSN = 'AC-34983-AA'"
+         asserting {
+            xpath '//Row/CustomerId' contains 'JonSnow'
+         }
+     }
+  }
+  ```
+  
+Below you find descriptions of the two JDBC specific assertions.
+
+### <a name="jdbcStatusOk></a>jdbcStatusOk
+
+Asserts that no error was returned from the database. Fails if an error was returned.
+
+**Arguments:** None
+
+**Example:** 
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+  
+   executeRecipe {
+      jdbcRequest {
+          driver 'com.mysql.Driver'
+          connectionString 'jdbc:mysql://staging-server/staging'
+          query "select CustomerId, Age from Customers where SSN = 'AC-34983-AA'"
+          asserting {
+             jdbcStatusOk
+          }
+      }
+   }
+ ```
+
+### timeout
+
+Asserts that the JDBC request completes before the timeout expires. Fails if the request takes longer than the 
+specified timeout.
+
+**Arguments:** An integer value specifying the timout in milliseconds.
+
+**Example:** 
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+  
+   executeRecipe {
+      jdbcRequest {
+          driver 'com.mysql.Driver'
+          connectionString 'jdbc:mysql://staging-server/staging'
+          query "select CustomerId, Age from Customers where SSN = 'AC-34983-AA'"
+          asserting {
+             timeout 3000
+          }
+      }
+   }
+ ```
+
+

--- a/modules/groovy-dsl/Jdbc-Request.md
+++ b/modules/groovy-dsl/Jdbc-Request.md
@@ -52,7 +52,7 @@ In other words, you can insert Groovy code inside it. You can also add comments 
 
 To veryify that the database request didn't just complete but also returned what you expected, you need to add assertions
 to your JDBC request step. To detect that an error was returned from the database, you need to add the 
-[jdbcStatusOk assertion](#jdbcStatusOk) The standard assertions [general-purpose assertions](Assertions.md#standard). 
+[jdbcStatusOk assertion](#jdbcStatusOk) The standard assertions [general-purpose assertions](Assertions.md#standard-assertions). 
 
 The following complete code example shows you how to verify that you got a result containing the text "JonSnow" back within
 3 seconds:

--- a/modules/groovy-dsl/Jdbc-Request.md
+++ b/modules/groovy-dsl/Jdbc-Request.md
@@ -52,7 +52,8 @@ In other words, you can insert Groovy code inside it. You can also add comments 
 
 To veryify that the database request didn't just complete but also returned what you expected, you need to add assertions
 to your JDBC request step. To detect that an error was returned from the database, you need to add the 
-[jdbcStatusOk assertion](#jdbcStatusOk) The standard assertions [general-purpose assertions](Assertions.md#standard-assertions). 
+```jdbcStatusOk``` assertion (see below). To verify that the correct data was returned from the database, use the 
+[general-purpose assertions](Assertions.md#standard-assertions), such as ```responseContains```. 
 
 The following complete code example shows you how to verify that you got a result containing the text "JonSnow" back within
 3 seconds:
@@ -106,7 +107,7 @@ The following code will assert that the returned CustomerId value is "JonSnow":
   
 Below you find descriptions of the two JDBC specific assertions.
 
-### <a name="jdbcStatusOk></a>jdbcStatusOk
+### jdbcStatusOk
 
 Asserts that no error was returned from the database. Fails if an error was returned.
 

--- a/modules/groovy-dsl/Property-Transfer.md
+++ b/modules/groovy-dsl/Property-Transfer.md
@@ -1,0 +1,115 @@
+# Property transfers - Transferring content in Assert4J DSL
+
+One of the most powerful features of [SoapUI](https://www.soapui.org) is the ability to easily transfer values from one test step
+to another in. This feature is known as ***Property transfer***. It is most often used to extract some part of it 
+and pass it into a subsequent request.
+
+Here's a simple example where we use JSONPath to replace the value ```WILL_BE_REPLACED``` with a customer ID
+extracted from the last response.
+
+```groovy
+import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+ executeRecipe {
+    get 'https://staging-server/customers/1'
+    transfer '$.customerId' to '$.customerId' of request
+    post 'https://staging-server/orders', '{ "customerId": "WILL_BE_REPLACED", "item": "ABC-123"}'
+ }
+ ```
+
+Property transfers understand both JSONPath and XPath expressions. You also don't have to specify a path - instead you 
+replace a property completely. See [Choosing the target property](#choose_property), below.
+
+## Choosing the target request
+ 
+If you want to transfer the value into a step other than the next one, you need to name the step in question.
+This is done with the ```name``` attribute in the configuration block of the request. In the code below,
+the POST request is named ```createOrder```, and this name is used by the two property transfer step to ensure that
+the correct parts of the posts are modified.
+
+```groovy
+import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+ executeRecipe {
+    get 'https://staging-server/customers/1'
+    transfer '$.customerId' to '$.customerId' of step: 'createOrder'
+    get 'https://staging-server/products/1'
+    transfer '$.id' to '$.item' of step: 'createOrder'
+    wait 1 second 
+    post 'https://staging-server/orders', {
+        name 'createOrder'
+        body '{ "customerId": "WILL_BE_REPLACED", "item": "WILL_BE_REPLACED"}'
+    }
+ }
+ ```
+
+## <a name="choose_property"></a>Choosing the target property
+
+In all examples above, property transfers were used to replace part of a POST. However, the value collected
+from the source step can also completely replace a property or parameter. This feature is especially useful
+if you have a basic understanding of how test steps and their properties interact in SoapUI.
+
+This code snippet demonstrates how to insert values into the Username and Password properties of the 
+next request:
+```groovy
+import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+ executeRecipe {
+    get 'https://staging-server/customers/1/credentials'
+    transfer '$.userName' to step: 'createOrder', property: 'Username'
+    transfer '$.password' to step: 'createOrder', property: 'Password'
+    post 'https://staging-server/orders', {
+        name 'createOrder'
+        body '{ "customerId": "JonSnow", "item": "ABC-123"}'
+    }
+ }
+ ```
+What properties are available for modification depends on the type of the step. For instance, 
+[this page](https://support.smartbear.com/readyapi/docs/projects/ui/request-properties/rest.html) lists the properties 
+of REST request steps; [this page](https://support.smartbear.com/readyapi/docs/projects/ui/request-properties/soap.html)
+documents what's available for SOAP requests.
+
+In addition to the standard properties, all parameters defined for a request will also be available for modification.
+In other words, if you have defined the parameter ```userName``` in the request named ```findOrder```, this property 
+transfer will modify it:
+```groovy
+transfer '$.password' to step: 'findOrder', property: 'userName'
+```
+
+This is a good way of transfering content into HTTP headers, as demonstrated in this code sample:
+```groovy
+import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+ executeRecipe {
+    get 'https://staging-server/session_cookies/1'
+    transfer '$.cookieValue' to step: 'createOrder', property: 'Set-Cookie'
+    post 'https://staging-server/orders', {
+        name 'createOrder'
+        body '{ "customerId": "JonSnow", "item": "ABC-123"}'
+        parameters {
+            header 'Set-Cookie', 'WILL_BE_REPLACED'
+        }
+    }
+ }
+ ```
+
+## Choosing the source of a transfer
+ 
+Although this is a less common scenario, sometimes it's useful to specify not the target, but ***from*** what step 
+and property you are transferring content. The syntax for this is similar to specifying the target, but
+for technical reasons you need to put the source and property parameters in parentheses.
+
+```groovy
+import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+ executeRecipe {
+    post 'https://staging-server/orders', {
+         name 'createOrder'
+         body '{ "customerId": "JonSnow", "item": "ABC-123"}'
+    }
+    transfer (step: 'createOrder', property: 'Response') to '$.lastOrderStatus' of request
+    put 'https://staging-server/customers/1/order_status', {
+        body '{ "lastOrderStatus": "WILL_BE_REPLACED"}'
+    }
+ }
+ ```

--- a/modules/groovy-dsl/Property-Transfer.md
+++ b/modules/groovy-dsl/Property-Transfer.md
@@ -1,7 +1,7 @@
 # Property transfers - Transferring content in Assert4J DSL
 
 One of the most powerful features of [SoapUI](https://www.soapui.org) is the ability to easily transfer values from one test step
-to another in. This feature is known as ***Property transfer***. It is most often used to extract some part of it 
+to another one. This feature is known as ***Property transfer***. It is most often used to extract some part of it 
 and pass it into a subsequent request.
 
 Here's a simple example where we use JSONPath to replace the value ```WILL_BE_REPLACED``` with a customer ID

--- a/modules/groovy-dsl/README.md
+++ b/modules/groovy-dsl/README.md
@@ -72,6 +72,10 @@ For detailed descriptions of the DSL features, click on the links below, or chec
 * [Database queries](JDBC-Request.md)
 * [Datasources](Datasources.md)
 
+## How to use the DSL in your build
+
+
+
 ## Tell us what's missing!
 
 If you've found a bug or are missing some kind of vocabulary/functionality/etc please contribute or 

--- a/modules/groovy-dsl/README.md
+++ b/modules/groovy-dsl/README.md
@@ -28,7 +28,7 @@ Here's an example (without import statements):
  }
  ```
  
-This test recipe will send a GET request to ```https://staging-server/customers/1```, then use a [http://goessner.net/articles/JsonPath/](JSONPath)
+This test recipe will send a GET request to ```https://staging-server/customers/1```, then use a [JSONPath](http://goessner.net/articles/JsonPath/)
 expression to find a value inside the response and insert it into a piece of JSON. Then it will send a POST with the modified JSON to the 
 endpoint ```https://staging-server/orders```.
 

--- a/modules/groovy-dsl/README.md
+++ b/modules/groovy-dsl/README.md
@@ -75,13 +75,13 @@ For detailed descriptions of the DSL features, click on the links below, or chec
 ## How to use the DSL in your build
 
 To compile and run tests using the Assert4J DSL in a Maven build, simply add this dependency (assuming that you are using
-version 1.0.0; if not just replace the contents of the ```version``` element):
+version 1.0.0-SNAPSHOT; if not just enter the version you use into the ```version``` element):
 
 ```xml
 <dependency>
     <groupId>io.swagger.assert</groupId>
     <artifactId>swagger-assert4j-groovy-dsl</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <scope>test</scope>
 </dependency>
  ```
@@ -92,7 +92,7 @@ your production code.
 To do the same thing in Gradle, add this line to the ```dependencies``` block:
 
 ```groovy
-runtime group: 'org.groovy', name: 'groovy', version: '2.2.0', ext: 'jar'
+testCompile group: 'io.swagger.assert', name: 'swagger-assert4j-groovy-dsl', version: '1.0.0-SNAPSHOT', ext: 'jar'
 ```
 
 ## Tell us what's missing!

--- a/modules/groovy-dsl/README.md
+++ b/modules/groovy-dsl/README.md
@@ -69,7 +69,7 @@ For detailed descriptions of the DSL features, click on the links below, or chec
 * [Assertions and test results](Assertions.md)
 * [Content transfer (Property transfer)](Property-Transfer.md)
 * [SOAP requests](Soap-Request.md) 
-* [Database queries](JDBC-Request.md)
+* [Database queries](Jdbc-Request.md)
 * [Datasources](Datasources.md)
 
 ## How to use the DSL in your build

--- a/modules/groovy-dsl/README.md
+++ b/modules/groovy-dsl/README.md
@@ -74,9 +74,28 @@ For detailed descriptions of the DSL features, click on the links below, or chec
 
 ## How to use the DSL in your build
 
+To compile and run tests using the Assert4J DSL in a Maven build, simply add this dependency (assuming that you are using
+version 1.0.0; if not just replace the contents of the ```version``` element):
 
+```xml
+<dependency>
+    <groupId>io.swagger.assert</groupId>
+    <artifactId>swagger-assert4j-groovy-dsl</artifactId>
+    <version>1.0.0</version>
+    <scope>test</scope>
+</dependency>
+ ```
+
+Generally ```test``` is the scope you want to us. If you don't the Assert4J DSL and its dependencies may be shipped with
+your production code.
+
+To do the same thing in Gradle, add this line to the ```dependencies``` block:
+
+```groovy
+runtime group: 'org.groovy', name: 'groovy', version: '2.2.0', ext: 'jar'
+```
 
 ## Tell us what's missing!
 
-If you've found a bug or are missing some kind of vocabulary/functionality/etc please contribute or 
+If you've found a bug or are missing some kind of vocabulary, functionality etc, please contribute or 
 open an issue!

--- a/modules/groovy-dsl/README.md
+++ b/modules/groovy-dsl/README.md
@@ -1,0 +1,78 @@
+# Domain-specific language (DSL) for tests
+
+We've created Swagger Assert4J to make the full functionality of SoapUI and ReadyApi 
+TestServer accessible to coders. However, we also had a more ambitious vision: to let testers and 
+other people with limited coding skills understand or even write API tests.
+
+We're trying to achieve this both with the [Cucumber functionality](../cucumber/README.md), and with our **Domain-specific language for tests**.
+
+## What is a domain-specific language?
+
+While most programming languages are general-purpose, a domain-specific language (DSL) by definition has a more limited scope. 
+In our case, the scope is to create API test and other integration tests. A DSL usually
+has simpler syntax and is more similar to a natural language, such as English.
+
+## The Assert4J DSL
+
+The Assert4J DSL is a so-called [internal DSL](https://martinfowler.com/bliki/InternalDslStyle.html), based on Groovy. 
+In other words the DSL scripts are Groovy code, which can be run inside any Groovy class or script, but we're trying hard 
+to make that code as similar to plain English as possible.
+
+Here's an example (without import statements):
+ 
+ ```groovy
+ runRecipe {
+    get 'https://staging-server/customers/1'
+    transfer '$.customerId' to '$.customerId' of request
+    post 'https://staging-server/orders', '{ "customerId": "id", "sku": "ABC-123", "quantity": "1"}'
+ }
+ ```
+ 
+This test recipe will send a GET request to ```https://staging-server/customers/1```, then use a [http://goessner.net/articles/JsonPath/](JSONPath)
+expression to find a value inside the response and insert it into a piece of JSON. Then it will send a POST with the modified JSON to the 
+endpoint ```https://staging-server/orders```.
+
+However, as it stands this is not really a test, because we're not checking what we're getting back from the server. Let's try
+something slightly more interesting, introducing the concepts of *assertions* and *test results*:
+
+```groovy
+ def testResult = executeRecipe {
+    post 'https://staging-server/orders', '{ "customerId": "JonSnow", "sku": "ABC-123", "quantity": "1"}'
+    wait 2 seconds
+    get 'https://staging-server/orders?filter=JonSnow', {
+        asserting {
+            status 200
+            responseContains 'PROCESSED'
+        }
+    }
+ }
+ assert testResult.currentReport.status != FAILED
+ ```
+ 
+ This piece of code will do the following:
+ 1. Send a POST with order data to the endpoint ```https://staging-server/orders```.
+ 2. Wait for 2 seconds after receiving the response (probably because some background processing task needs to complete)
+ 3. Send a GET to the URL ```https://staging-server/orders?filter=JonSnow``` and verify
+    + that the request returned 200 OK
+    + that the response contains the text PROCESSED
+ 4. After running the recipe, either locally or on a TestServer, use a standard Groovy assert to check that the requests completed, 
+ and that the HTTP status and response met our expectations. 
+ 
+Although we hope that these two examples got you interested in the Assert4J DSL, we've really only
+scratched the surface of what you can do with it. In addition to REST requests, content transfer and a wide range of assertions,
+the DSL can e.g. send SOAP requests with a minimum of code, execute database queries using JDBC, read test data from
+Excel and CSV files and generate random test data values (such as ZIP codes).
+
+For detailed descriptions of the DSL features, click on the links below, or check out the [samples](../samples) submodule for more examples.
+
+* [REST requests](Rest-Request.md)
+* [Assertions and test results](Assertions.md)
+* [Content transfer (Property transfer)](Property-Transfer.md)
+* [SOAP requests](Soap-Request.md) 
+* [Database queries](JDBC-Request.md)
+* [Datasources](Datasources.md)
+
+## Tell us what's missing!
+
+If you've found a bug or are missing some kind of vocabulary/functionality/etc please contribute or 
+open an issue!

--- a/modules/groovy-dsl/Rest-Request.md
+++ b/modules/groovy-dsl/Rest-Request.md
@@ -136,7 +136,7 @@ In addition to the general-purpose [assertions](Assertions.md) for things like s
 time, there are more specific assertions for checking HTTP statuses and headers and using JsonPath expressions to validate
 parts of the response (XPath is part of the generic assertion support).
 
-The following complete code example shows you both generic assertions and HTTP-specific ones:
+The following complete code example shows you both generic assertions and ones that are only applicable to REST and HTTP.
 
 ```groovy
  import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
@@ -158,7 +158,9 @@ The following complete code example shows you both generic assertions and HTTP-s
   }
   ```
 
-Below you will find a complete all the HTTP-specific assertions, which complement the (standard assertions)[Assertions.md].
+In addition to the [standard assertions](Assertions.md#standard) and the [HTTP-specific ones](Assertions.md#http-specific), 
+the following JsonPath assertions are available for REST requests. They all use JsonPath to verify the content
+in the response body.
 
 ### jsonPath <EXPRESSION> contains <EXPECTED_CONTENT>
 

--- a/modules/groovy-dsl/Rest-Request.md
+++ b/modules/groovy-dsl/Rest-Request.md
@@ -158,7 +158,7 @@ The following complete code example shows you both generic assertions and ones t
   }
   ```
 
-In addition to the [standard assertions](Assertions.md#standard) and the [HTTP-specific ones](Assertions.md#http-specific), 
+In addition to the [standard assertions](Assertions.md#standard-assertions) and the [HTTP-specific ones](Assertions.md#http-specific-assertions), 
 the following JsonPath assertions are available for REST requests. They all use JsonPath to verify the content
 in the response body.
 

--- a/modules/groovy-dsl/Rest-Request.md
+++ b/modules/groovy-dsl/Rest-Request.md
@@ -129,7 +129,7 @@ To tell a DSL script to go and fetch the page you've been redirected to, use the
 
 ## Adding assertions to the response
 
-The Assert4J DSL is a **Test** DSL, you're really not putting it to good use unless you verify the responses you
+The Assert4J DSL is a **Test** DSL, so you're really not putting it to good use unless you verify the responses you
 get back. This is done in an ```asserting``` section in your configuration block.
 
 In addition to the general-purpose [assertions](Assertions.md) for things like simple content and the response

--- a/modules/groovy-dsl/Rest-Request.md
+++ b/modules/groovy-dsl/Rest-Request.md
@@ -1,0 +1,211 @@
+# REST requests in Assert4J DSL
+
+To send a REST request from a DSL script, you need to call one of the methods in the class 
+```io.swagger.assert4j.dsl.TestDsl```. For every HTTP verb, there's a corresponding method with a lower case
+name that you can call to send a request to a certain URI. In the case of POST and PUT, you can also
+add the body you want to send to the server as the second parameter.
+
+ ```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+ executeRecipe {
+    get 'https://staging-server/customers/1?includeSSN=true'
+    post 'https://staging-server/orders', '{ "customerId": "id", "sku": "ABC-123", "quantity": "1"}'
+    put 'https://staging-server/orders/1', '{ "customerId": "id", "sku": "ABC-123", "quantity": "2"}'
+    delete 'https://staging-server/customers/1'
+    head 'https://staging-server/orders'
+    options 'https://staging-server/orders'
+    trace 'https://staging-server/orders'
+ }
+ ```
+ 
+To modify the HTTP requests in different ways, you pass in a ***configuration block*** as the second
+parameter to one of the HTTP methods inside a set of curly braces. Here is an example where you set the body and the 
+content type of a post and add a Set-Cookie header to the request:
+ 
+ ```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+  executeRecipe {
+     post 'https://staging-server/orders/1/status', {
+         contentType 'text/plain'
+         header 'Set-Cookie', 'user=admin'
+         body 'COMPLETED'
+     }
+     
+  }
+  ```
+ 
+In the sections below we will describe all the things you can tweak in the configuration block of a request.
+ 
+**Technical note**: The configuration block is a Groovy closure, which will be executed before the request is sent. 
+In other words, you can insert Groovy code inside it. You can also add comments to document what you're doing.
+ 
+ ## Setting parameters and request headers
+ 
+Swagger Assert4J supports four different kinds of REST parameters, which can all be set inside a configuration block:
+* query parameters, set in the query string
+* path parameters, set in the resource path
+* matrix parameters, appended after the resource path proper
+* header parameters, set as HTTP request headers
+
+Here's an example of how to set these four types in a configuration block:
+
+```groovy
+ get 'https://staging-server/customers/{id}', {
+     parameters {
+         path 'id', '123'
+         matrix 'a', '1'
+         query 'b', '2'
+         headerParam 'c', '3'
+     }
+ }
+```
+
+Query, path and matrix parameters can all be manually sent as part of the URI, if you think this is clearer, and instead of
+using a headerParam entry, you can simply set the header. For instance,
+the following request URI contains an "implicit" path parameter with the value 123, the matrix parameter ```a``` 
+and the query parameter ```b```, and a header named ```c```:
+```groovy
+ get 'https://staging-server/customers/123;a=1?b=2', {
+     header 'c', '3'
+ }
+```
+Note that you don't need to use the parameters section to set an HTTP request header. If you want to set several request 
+headers in one go, you can use a ```headers``` entry and pass a Groovy map:
+
+```groovy
+ get 'https://staging-server/customers/123;a=1?b=2', {
+     headers ['Set-Cookie': 'user=admin123', 'Max-Age': 3600]
+ }
+```
+
+This is equivalent to the following:
+
+```groovy
+ get 'https://staging-server/customers/123;a=1?b=2', {
+     header 'Set-Cookie', 'user=admin123'
+     header 'Max-Age', 3600
+ }
+```
+
+## Posting (and putting) content
+
+If the request is a POST or PUT, you will naturally need to configure what you are posting. This is done with the entries
+```contentType``` and ```body```. Here's an example:
+
+```groovy
+ put 'https://staging-server/customers/123;a=1?b=2', {
+     contentType 'application/json'
+     body '{ "customerId": "id", "sku": "ABC-123", "quantity": "1"}'
+ }
+```
+
+As seen above, if you want to POST or PUT application/json, you can also use the short form of the put and post methods,
+where you pass the body as the second parameter:
+```groovy
+    post 'https://staging-server/orders', '{ "customerId": "id", "sku": "ABC-123", "quantity": "1"}'
+    put 'https://staging-server/orders/1', '{ "customerId": "id", "sku": "ABC-123", "quantity": "2"}'
+```
+
+Another common scenario is that you want to POST the query string. In this case using the ```body``` entry, so we recommend
+that you configure your request like this:
+```groovy
+    post 'https://staging-server/orders?customerId=123&sku=ABC-123', {
+        postQueryString true
+    }
+```
+
+## Following redirects
+
+By default the DSL will treat an HTTP redirect as just another response and not request. By setting the followRedirects.
+To tell a DSL script to go and fetch the page you've been redirected to, use the ```followRedirects``` option, like this:
+
+```groovy
+    post 'https://staging-server/old_page', {
+        followRedirects true
+    }
+```
+
+## Adding assertions to the response
+
+The Assert4J DSL is a **Test** DSL, you're really not putting it to good use unless you verify the responses you
+get back. This is done in an ```asserting``` section in your configuration block.
+
+In addition to the general-purpose [assertions](Assertions.md) for things like simple content and the response
+time, there are more specific assertions for checking HTTP statuses and headers and using JsonPath expressions to validate
+parts of the response (XPath is part of the generic assertion support).
+
+The following complete code example shows you both generic assertions and HTTP-specific ones:
+
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+  executeRecipe {
+     post 'https://staging-server/orders/1/status', {
+         asserting {
+            /* Standard assertions */
+            responseContains 'COMPLETED'
+            responseDoesNotContain 'CANCELLED'
+            maxResponseTime 3500 // measured in milliseconds
+            
+            /* REST/HTTP assertions */
+            status 200
+            jsonExists '$.orderStatus'
+         }
+     }
+     
+  }
+  ```
+
+Below you will find a complete all the HTTP-specific assertions, which complement the (standard assertions)[Assertions.md].
+
+### jsonPath <EXPRESSION> contains <EXPECTED_CONTENT>
+
+Extracts the element in the response matching the JsonPath in ```EXPRESSION``` and fails the assertion 
+if it isn't equal to ```EXPECTED_CONTENT```.
+
+**Parameters:** A string containing the JsonPath expression and another string with the expected content.
+
+**Example:** 
+```groovy
+ get 'https://staging-server/customers/1', {
+     asserting {
+         jsonPath '$.customerId' contains 'JonSnow'
+     }
+ }
+ ```
+ 
+### jsonPathExists
+ 
+ Tries to find the element in the response matching the JsonPath in the parameter and fails the assertion if 
+ it doesn't exist.
+ 
+ **Parameter:** A string containing the JsonPath expression identifying the element.
+ 
+ **Example:** 
+ ```groovy
+  get 'https://staging-server/customers/1', {
+      asserting {
+          jsonPathExists '$.customerId'
+      }
+  }
+  ```
+ 
+### jsonPath <EXPRESSION> occurs <NUMBER> times
+
+Counts the number of elements in the response matching the JsonPath in ```EXPRESSION``` and fails the assertion 
+if the number of elements is not equal to ```NUMBER```.
+
+**Arguments:** A string containing the JsonPath expression and an integer with the expected element count.
+
+**Example:** 
+```groovy
+ get 'https://staging-server/customers/1/orders', {
+     asserting {
+         jsonPath '$.order' occurs 3 times
+     }
+ }
+ ```
+
+

--- a/modules/groovy-dsl/Soap-Request.md
+++ b/modules/groovy-dsl/Soap-Request.md
@@ -57,11 +57,11 @@ name. Using a ```pathParam``` with XPath will help resolve this:
 To verify that you are getting the expected response back from your web service, you should add assertions to the SOAP
  request step. This is done in an ```asserting``` section in your configuration block.
 
-In addition to the general-purpose [assertions](Assertions.md#standard) for things like simple content and the response
+In addition to the general-purpose [assertions](Assertions.md#standard-assertions) for things like simple content and the response
 time, there are more specific assertions for checking the correctness of the web service response. The XPath assertions 
 are particularly useful for SOAP responses since they will always be in XML format.
 
-The [HTTP-specific assertions](Assertions.md#http-specific) are also applicable to all SOAP requests – 
+The [HTTP-specific assertions](Assertions.md#http-specific-assertions) are also applicable to all SOAP requests – 
 
 The following complete code example shows you three generic content and response time assertions:
 

--- a/modules/groovy-dsl/Soap-Request.md
+++ b/modules/groovy-dsl/Soap-Request.md
@@ -1,0 +1,110 @@
+# SOAP requests in Assert4J DSL
+
+To send a SOAP request from a DSL script, you need to call the ```soapRequest``` method and
+provide a URL to the WSDL. You also need to identify the binding and operation you want to call.
+
+Here's a simple example where no parameters are passed into the SOAP request:
+
+```groovy
+import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+ executeRecipe {
+    soapRequest {
+        wsdl = 'http://www.webservicex.com/globalweather.asmx?WSDL'
+        binding = 'GlobalWeatherSoap12'
+        operation = 'GetCitiesByCountry'
+    }
+ }
+ ```
+ 
+## Setting parameters
+ 
+Most SOAP requests have parameters – variable data. Parameters can be set by name or by path, using the commands
+```namedParam``` and ```pathParam```, respectively.
+
+Named parameter finds an XML element using the local name of the element. 
+The following code passes the value "France" into the XML element:
+
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+  
+  executeRecipe {
+     soapRequest {
+         wsdl = 'http://www.webservicex.com/globalweather.asmx?WSDL'
+         binding = 'GlobalWeatherSoap12'
+         operation = 'GetCitiesByCountry'
+         namedParam 'CountryName', 'France'
+     }
+  }
+```
+In some cases the local name will be ambiguous, however - the corresponding XML will have several elements with the same
+name. Using a ```pathParam``` with XPath will help resolve this:
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+  
+  executeRecipe {
+     soapRequest {
+         wsdl = 'http://www.webservicex.com/globalweather.asmx?WSDL'
+         binding = 'GlobalWeatherSoap12'
+         operation = 'GetCitiesByCountry'
+         pathParam '//GetCitiesByCountry/CountryName', 'France'
+     }
+  }
+```
+
+## Adding assertions to the SOAP response
+
+To verify that you are getting the expected response back from your web service, you should add assertions to the SOAP
+ request step. This is done in an ```asserting``` section in your configuration block.
+
+In addition to the general-purpose [assertions](Assertions.md#standard) for things like simple content and the response
+time, there are more specific assertions for checking the correctness of the web service response. The XPath assertions 
+are particularly useful for SOAP responses since they will always be in XML format.
+
+The [HTTP-specific assertions](Assertions.md#http-specific) are also applicable to all SOAP requests – 
+
+The following complete code example shows you three generic content and response time assertions:
+
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+  executeRecipe {
+    soapRequest {
+           wsdl = 'http://www.webservicex.com/globalweather.asmx?WSDL'
+           binding = 'GlobalWeatherSoap12'
+           operation = 'GetCitiesByCountry'
+           namedParam 'CountryName', 'France'
+           asserting {
+               responseContains 'Paris'
+               responseDoesNotContain 'London'
+               maxResponseTime 3500 ms
+           }
+       }
+     
+  }
+```
+
+The following code example demonstrates the use of the HTTP status assertion, and the two SOAP-specific assertions ```notSoapFault``` and
+```schemaCompliance```. The former will fail if a SOAP fault is returned by the web service; the latter if the response
+payload doesn't comply with the schema defined in the WSDL of the web service.
+
+```groovy
+ import static io.swagger.assert4j.dsl.execution.RecipeExecution.executeRecipe
+ 
+  executeRecipe {
+    soapRequest {
+           wsdl = 'http://www.webservicex.com/globalweather.asmx?WSDL'
+           binding = 'GlobalWeatherSoap12'
+           operation = 'GetCitiesByCountry'
+           namedParam 'CountryName', 'France'
+           asserting {
+               status 200
+               notSoapFault
+               schemaCompliance
+           }
+       }
+     
+  }
+```
+
+

--- a/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/DslDelegate.groovy
+++ b/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/DslDelegate.groovy
@@ -52,6 +52,13 @@ class DslDelegate {
         createRestRequest('PUT', URI, configuration)
     }
 
+    void put(String URI, String bodyString) {
+        put(URI, {
+            contentType 'application/json'
+            body bodyString
+        })
+    }
+
     void delete(String URI, @DelegatesTo(RestRequestDelegate) Closure configuration = null) {
         createRestRequest('DELETE', URI, configuration)
     }

--- a/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/DslDelegate.groovy
+++ b/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/DslDelegate.groovy
@@ -133,6 +133,7 @@ class DslDelegate {
 
         JdbcRequestTestStepBuilder builder = new JdbcRequestTestStepBuilder(delegate.driver, delegate.connectionString,
                 delegate.storedProcedure)
+                .withSql(delegate.query)
         builder.named(delegate.testStepName)
         if (delegate.testStepProperties) {
             builder.withProperties(delegate.testStepProperties)

--- a/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/JdbcRequestDelegate.groovy
+++ b/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/JdbcRequestDelegate.groovy
@@ -13,6 +13,7 @@ class JdbcRequestDelegate {
     boolean storedProcedure;
     Map<String, String> testStepProperties
     List<AssertionBuilder> assertions
+    String query
 
     void name(String testStepName) {
         this.testStepName = testStepName;
@@ -24,6 +25,10 @@ class JdbcRequestDelegate {
 
     void connectionString(String connectionString) {
         this.connectionString = connectionString;
+    }
+
+    void query(String query) {
+        this.query = query
     }
 
     void storedProcedure(boolean storedProcedure) {

--- a/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/assertions/AbstractHttpAssertionsDelegate.groovy
+++ b/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/assertions/AbstractHttpAssertionsDelegate.groovy
@@ -12,11 +12,23 @@ import static io.swagger.assert4j.assertions.Assertions.notContains
 /**
  * An abstract class which contains common assertions applicable to multiple requests: SOAP, REST etc.
  */
-abstract class AbstractAssertionsDelegate {
+abstract class AbstractHttpAssertionsDelegate extends AbstractAssertionsDelegate {
     private List<AssertionBuilder> assertionBuilders = []
 
     List<AssertionBuilder> getAssertionBuilders() {
         return assertionBuilders
+    }
+
+    /**
+     * Creates assertion to validate the status code in the response
+     * @param httpStatuses status codes which should be present in the response
+     */
+    void status(int ... httpStatuses) {
+        ValidHttpStatusCodesAssertionBuilder builder = new ValidHttpStatusCodesAssertionBuilder()
+        for (int httpStatus : httpStatuses) {
+            builder.addStatusCode(httpStatus)
+        }
+        assertionBuilders.add(builder)
     }
 
     /**
@@ -48,11 +60,31 @@ abstract class AbstractAssertionsDelegate {
     }
 
     /**
+     * Creates assertion to validate the absence of status codes in the response
+     * @param invalidStatuses status codes which should not be present in the response
+     */
+    void statusNotIn(int ... invalidStatuses) {
+        InvalidHttpStatusCodesAssertionBuilder builder = new InvalidHttpStatusCodesAssertionBuilder()
+        for (int httpStatus : invalidStatuses) {
+            builder.addStatusCode(httpStatus)
+        }
+        assertionBuilders.add(builder)
+    }
+
+    /**
      * Creates an assertion with script to validate the response as per the script
      * @param scriptText script to be executed on the response
      */
     void script(String scriptText) {
         assertionBuilders.add(Assertions.script(scriptText))
+    }
+
+    /**
+     * Creates assertions to validate the value of "Content-Type" header in the response
+     * @param contentType expected content type of the response
+     */
+    void responseContentType(String contentType) {
+        assertionBuilders.add(Assertions.contentType(contentType))
     }
 
     /**

--- a/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/assertions/JdbcAssertionDelegate.groovy
+++ b/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/assertions/JdbcAssertionDelegate.groovy
@@ -20,7 +20,7 @@ class JdbcAssertionDelegate extends AbstractAssertionsDelegate {
     }
 
     /**
-     * Creates delegate to add timeut assertion on JDBC request
+     * Creates delegate to add timeout assertion on JDBC request
      * @param timeout value to assert that JDBC request was executed within this time, assertion fails if request takes
      *                  more time than 'timeout'
      * @return TimeBasedAssertionDelegate

--- a/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/assertions/RestRequestAssertionsDelegate.groovy
+++ b/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/assertions/RestRequestAssertionsDelegate.groovy
@@ -5,7 +5,7 @@ import io.swagger.assert4j.assertions.Assertions
 /**
  * The delegate to respond to commands inside 'asserting' closure of REST request
  */
-class RestRequestAssertionsDelegate extends AbstractAssertionsDelegate {
+class RestRequestAssertionsDelegate extends AbstractHttpAssertionsDelegate {
 
     /**
      * Creates delegate for JSON path assertion.

--- a/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/assertions/SoapRequestAssertionsDelegate.groovy
+++ b/modules/groovy-dsl/src/main/groovy/io/swagger/assert4j/dsl/assertions/SoapRequestAssertionsDelegate.groovy
@@ -9,7 +9,7 @@ import io.swagger.assert4j.assertions.SoapFaultAssertionBuilder
 /**
  * The delegate to respond to commands inside 'asserting' closure of SOAP request
  */
-class SoapRequestAssertionsDelegate extends AbstractAssertionsDelegate {
+class SoapRequestAssertionsDelegate extends AbstractHttpAssertionsDelegate {
 
     /**
      * Creates 'SOAP Fault' assertion.

--- a/modules/groovy-dsl/src/test/groovy/io/swagger/assert4j/dsl/JdbcRequestDslTest.groovy
+++ b/modules/groovy-dsl/src/test/groovy/io/swagger/assert4j/dsl/JdbcRequestDslTest.groovy
@@ -17,6 +17,7 @@ class JdbcRequestDslTest {
                 name 'Jdbc'
                 driver 'org.h2.Driver'
                 connectionString 'jdbc:h2:~/.readyapi/db/readyapi'
+                query 'select * from customers'
                 storedProcedure false
                 testStepProperties property1: 'value1', property2: 'value2'
             }
@@ -26,6 +27,7 @@ class JdbcRequestDslTest {
         assert jdbcRequestStep.name == 'Jdbc'
         assert jdbcRequestStep.driver == 'org.h2.Driver'
         assert jdbcRequestStep.connectionString == 'jdbc:h2:~/.readyapi/db/readyapi'
+        assert jdbcRequestStep.sqlQuery == 'select * from customers'
         assert !jdbcRequestStep.storedProcedure
         assert jdbcRequestStep.properties == [property1: 'value1', property2: 'value2']
     }

--- a/modules/groovy-dsl/src/test/groovy/io/swagger/assert4j/dsl/PropertyTransferDslTest.groovy
+++ b/modules/groovy-dsl/src/test/groovy/io/swagger/assert4j/dsl/PropertyTransferDslTest.groovy
@@ -40,7 +40,7 @@ class PropertyTransferDslTest {
             get URI, {
                 name FIRST_STEP
             }
-            transfer sourcePath from DslDelegate.response to targetPath of DslDelegate.request
+            transfer sourcePath from response to targetPath of request
             post URI, {
                 name LAST_STEP
             }
@@ -61,7 +61,7 @@ class PropertyTransferDslTest {
     @Test
     void buildsPropertyTransferWithNameInClosure() throws Exception {
         TestRecipe recipe = recipe {
-            transfer sourcePath name TEST_STEP_NAME from DslDelegate.response to targetPath of DslDelegate.request
+            transfer sourcePath name TEST_STEP_NAME from response to targetPath of request
         }
         PropertyTransferTestStep propertyTransferStep = recipe.testCase.testSteps[0] as PropertyTransferTestStep
         assert propertyTransferStep.name == TEST_STEP_NAME
@@ -73,7 +73,7 @@ class PropertyTransferDslTest {
             get URI, {
                 name FIRST_STEP
             }
-            transfer sourcePath from DslDelegate.response to targetPath of(step: 'TheStep', property: 'Username')
+            transfer sourcePath from response to targetPath of(step: 'TheStep', property: 'Username')
             post URI, {
                 name LAST_STEP
             }
@@ -100,7 +100,7 @@ class PropertyTransferDslTest {
     @Test
     void buildsCorrectTargetWithSpecialSyntaxAndMaps() throws Exception {
         TestRecipe recipe = recipe {
-            transfer sourcePath from DslDelegate.response to(step: 'someStep', property: 'SomeProperty', path: targetPath)
+            transfer sourcePath from response to(step: 'someStep', property: 'SomeProperty', path: targetPath)
         }
 
         PropertyTransfer transferStep = extractPropertyTransferFromTestStep(recipe)

--- a/modules/groovy-dsl/src/test/groovy/io/swagger/assert4j/dsl/RestRequestDslTest.groovy
+++ b/modules/groovy-dsl/src/test/groovy/io/swagger/assert4j/dsl/RestRequestDslTest.groovy
@@ -80,6 +80,25 @@ class RestRequestDslTest {
     }
 
     @Test
+    void buildsRecipeWithPUTAndBody() throws Exception {
+        String body = """
+            {
+                "customerId": "some_id",
+                "lineItems": [
+                  { sku: 'ABC-123', quantity: 2},
+                  { sku: 'DEF-456', quantity: 1}
+            }
+            """
+        TestRecipe recipe = recipe {
+            put URI, body
+        }
+
+        RestTestRequestStep requestStep = recipe.testCase.testSteps[0] as RestTestRequestStep
+        assert requestStep.requestBody == body
+        assert requestStep.mediaType == 'application/json'
+    }
+
+    @Test
     void buildsRecipeWithDELETE() throws Exception {
         TestRecipe recipe = recipe {
             delete URI

--- a/modules/groovy-dsl/src/test/groovy/io/swagger/assert4j/dsl/RestRequestDslTest.groovy
+++ b/modules/groovy-dsl/src/test/groovy/io/swagger/assert4j/dsl/RestRequestDslTest.groovy
@@ -320,7 +320,7 @@ class RestRequestDslTest {
         TestRecipe recipe = recipe {
             get '/some_uri', {
                 asserting {
-                    contentType 'text/xml'
+                    responseContentType 'text/xml'
                 }
             }
         }


### PR DESCRIPTION
This adds a set of Markdown documentation pages for the Groovy DSL.

It also contains improvements and adds features that were conspicuously missing from the DSL.

NOTE: Too read the documentation as it will appear on Github, start browsing it here:
https://github.com/SmartBear/swagger-assert4j/tree/TSERV-261-groovy-dsl-documentation/modules/groovy-dsl